### PR TITLE
Added deleteUnique function and Unique getter to HKey

### DIFF
--- a/Data/HKey.hs
+++ b/Data/HKey.hs
@@ -2,10 +2,11 @@ module Data.HKey(  HKey
             , withKey
             , T
             , createKey
+            , unique
             -- * Key Monad
             , KeyM
             , KeyT
-            , Key 
+            , Key
             , runKey
             , newKey
             , getKey

--- a/Data/HKeyPrivate.hs
+++ b/Data/HKeyPrivate.hs
@@ -15,6 +15,7 @@ module Data.HKeyPrivate(
             , withKey
             , T
             , createKey
+            , unique
             , KeyM
             , KeyT
             , Key
@@ -71,6 +72,8 @@ data T
 createKey :: IO (HKey T a)
 createKey = fmap Key newUnique
 
+unique :: HKey t a -> Unique
+unique (Key u) = u
 
 {--------------------------------------------------------------------
   Key Monad
@@ -185,7 +188,3 @@ runKeyT (KeyT m) = loop m where
   bind GetKey  c = unsafePerformIO (liftM (loop . c) createKey)
   bind (Split (KeyT m)) c = loop $ c $ loop m
   bind (GDFix f) c = mfix (loop . getKT . f) >>= loop . c
-
-
-
-

--- a/Data/HMap.hs
+++ b/Data/HMap.hs
@@ -366,6 +366,16 @@ delete (Key k) (HMap m) = HMap $ M.delete k m
 {-# INLINE delete #-}
 #endif
 
+-- | /O(log n)/. Delete a value from the map using Unique instead of HKey
+deleteUnique :: Unique -> HMap -> HMap
+deleteUnique u (HMap m) = HMap $ M.delete u m
+#if __GLASGOW_HASKELL__ >= 700
+{-# INLINABLE deleteUnique #-}
+#else
+{-# INLINE deleteUnique #-}
+#endif
+
+
 -- | /O(log n)/. Update a value at a specific key with the result of the provided function.
 -- When the key is not
 -- a member of the map, the original map is returned.


### PR DESCRIPTION
Added a possibility to get `Unique` from keys and use it to delete values from `HMap`. `Unique` values because of its common type can make managing items in HMap easier
