### PR TITLE
Work with newer "hashable" versions.

### DIFF
--- a/Data/HKeyPrivate.hs
+++ b/Data/HKeyPrivate.hs
@@ -35,8 +35,10 @@ import Control.Monad.Trans
 import Control.Monad.Fix
 import Data.Hashable
 
+#if !(MIN_VERSION_hashable(1,2,4))
 instance Hashable Unique where
   hashWithSalt n u = n + hashUnique u
+#endif
 
 
 {--------------------------------------------------------------------

--- a/HMap.cabal
+++ b/HMap.cabal
@@ -1,7 +1,7 @@
 Name:                HMap
-Version:             1.2.3
-Synopsis:            Fast heterogeneous maps and unconstrained typeable like functionality.
-Description:         Fast heterogeneous maps based on Hashmaps and type-able like functionality for type that are not typeable.
+Version:             1.3.0
+Synopsis:            Fast heterogeneous maps and unconstrained typeable-like functionality.
+Description:         Fast heterogeneous maps based on Hashmaps and typeable-like functionality for types that are not typeable.
 License:             BSD3
 License-file:        LICENSE
 Author:              Atze van der Ploeg
@@ -12,11 +12,23 @@ Cabal-Version:       >=1.6
 Data-files:          ChangeLog
 Category:            Data, Data Structures
 Tested-With:         GHC==7.6.3
+                   , GHC==7.10.3
 Library
-  Build-Depends: base >= 2 && <= 6, data-default, unordered-containers >= 0.2, hashable >= 1.2, mtl >= 1.0
-  Exposed-modules: Data.HMap, Data.HKey, Data.Untypeable, Data.HKeySet
-  other-modules:       Data.HKeyPrivate, Data.HideType
-  Extensions:	 RankNTypes, GADTs, CPP, EmptyDataDecls
+  Build-Depends:   base >= 2 && <= 6
+                 , data-default
+                 , unordered-containers >= 0.2
+                 , hashable >= 1.2
+                 , mtl >= 1.0
+  Exposed-modules: Data.HMap
+                 , Data.HKey
+                 , Data.Untypeable
+                 , Data.HKeySet
+  other-modules:   Data.HKeyPrivate
+                 , Data.HideType
+  Extensions:      RankNTypes
+                 , GADTs
+                 , CPP
+                 , EmptyDataDecls
 
 source-repository head
     type:     git


### PR DESCRIPTION
Newer versions of the "hashable" package provide a Hashable instance for Unique. 1.2.4 seems to be the earliest "hashable" version to provide such an instance.

The "hashable" package is free to provide an instance with different behavior in the future, hence the bump form 1.2 to 1.3.
